### PR TITLE
Update build.sh to include arm64 for all platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ NAME=aws-env
 mkdir $BUILD_DIR
 
 for GOOS in darwin linux windows; do
-    for GOARCH in 386 amd64; do
+    for GOARCH in 386 amd64 arm64; do
         GOOS=$GOOS GOARCH=$GOARCH go build -v -o $BUILD_DIR/$NAME-$GOOS-$GOARCH
     done
 done


### PR DESCRIPTION
Currently the build.sh only accommodates x86 and x86_64 architectures. This adds arm64 for all three supported platforms.