### PR TITLE
ci: [PIE-1449] Add workflow to automatically close stale PRs

### DIFF
--- a/.github/workflows/close-inactive-prs.yml
+++ b/.github/workflows/close-inactive-prs.yml
@@ -1,0 +1,24 @@
+name: Close inactive PRs
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      actions: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR is stale because it has been open for 21 days with no activity."
+          close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-pr-labels: "dependencies"


### PR DESCRIPTION
This PR adds a nightly workflow that marks PRs as stale after 21 days of inactivity, then closes them after 7 more days of inactivity